### PR TITLE
corrected path for static files served in production build

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -46,10 +46,10 @@ app.use('/recipeAPI/ingredientSearch', ingredientSearch);
 // Serve static assets if in production
 if (process.env.NODE_ENV === 'production') {
   // Set static folder
-  app.use(express.static('client/build'));
+  app.use(express.static('../client/build'));
 
   app.get('*', (req, res) => {
-    res.sendFile(path.resolve(__dirname, 'client', 'build', 'index.html'));
+    res.sendFile(path.resolve(__dirname, '..', 'client', 'build', 'index.html'));
   });
 }
 


### PR DESCRIPTION
The path for the static files served for production build was incorrect in file `AutoMeal/server/app.js`.
Since all backend was moved to `server/` the path need to be updated to move out of server (i.e. `../server/`) and then into `client/build`